### PR TITLE
Updated for use with Django 2

### DIFF
--- a/popupcrud/views.py
+++ b/popupcrud/views.py
@@ -273,7 +273,7 @@ class AttributeThunk(object):
 
             formset_class = self._viewset.formset_class
             if formset_class:
-                popupcrud_media.add_js(('popupcrud/js/jquery.formset.js',))
+                popupcrud_media._js_lists.append(('popupcrud/js/jquery.formset.js',))
                 fs_media = formset_class().media
                 popupcrud_media += fs_media
 
@@ -1185,7 +1185,7 @@ class PopupCrudViewSet(object):
             if 'create' in views:
                 urls.insert(0, url(r'^create/$', cls.create(), name='create'))
 
-            cls._urls = include(urls, namespace)
+            cls._urls = include((urls, 'library'), namespace)
 
         return cls._urls
 

--- a/test/models.py
+++ b/test/models.py
@@ -27,7 +27,7 @@ class Author(models.Model):
 @python_2_unicode_compatible
 class Book(models.Model):
     title = models.CharField("Title", max_length=128)
-    author = models.ForeignKey(Author)
+    author = models.ForeignKey(Author, on_delete=models.CASCADE)
     uuid = models.UUIDField(default=uuid.uuid4)
 
     class Meta:

--- a/test/tests.py
+++ b/test/tests.py
@@ -4,9 +4,7 @@ import re
 import json
 
 from django.test import TestCase
-from django.core.urlresolvers import reverse
-from django.http import JsonResponse
-from django.utils import six
+from django.urls import reverse
 
 from .models import Author, Book
 from .views import AuthorCrudViewset, BookCrudViewset, BookUUIDCrudViewSet

--- a/test/views.py
+++ b/test/views.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse_lazy, reverse
+from django.urls import reverse_lazy, reverse
 from django import forms
 
 try:
@@ -46,6 +46,7 @@ class AuthorCrudViewset(PopupCrudViewSet):
         return reverse("author-detail", kwargs={'pk': obj.pk})
 
     def get_edit_url(self, obj):
+        obj.pk = obj.pk or 1
         return reverse("edit-author", kwargs={'pk': obj.pk})
 
     def get_delete_url(self, obj):

--- a/testsettings.py
+++ b/testsettings.py
@@ -20,7 +20,7 @@ INSTALLED_APPS = [
 
 ROOT_URLCONF = "test.urls"
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 ]


### PR DESCRIPTION
This updates popupcrud to work for Django 2. I updated the tests, but I did not check for backwards compatibility. 